### PR TITLE
Update git2go to the latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Install git2go
         run: |
           export GOPATH="$(go env GOPATH)"
-          go mod edit -replace "github.com/lhchavez/git2go/v32=${GOPATH}/src/github.com/lhchavez/git2go"
-          git clone --recurse-submodules https://github.com/lhchavez/git2go -b v32.0.0-prerelease.0 "${GOPATH}/src/github.com/lhchavez/git2go"
-          go get -d github.com/lhchavez/git2go/v32
-          (cd "${GOPATH}/src/github.com/lhchavez/git2go/" && ./script/build-libgit2-static.sh)
+          go mod edit -replace "github.com/libgit2/git2go/v32=${GOPATH}/src/github.com/libgit2/git2go"
+          git clone --recurse-submodules https://github.com/libgit2/git2go -b v32.0.4 "${GOPATH}/src/github.com/libgit2/git2go"
+          go get -d github.com/libgit2/git2go/v32
+          (cd "${GOPATH}/src/github.com/libgit2/git2go/" && USE_CHROMIUM_ZLIB=ON ./script/build-libgit2-static.sh)
 
       - name: Lint
         run: golint -set_exit_status ./...

--- a/browser.go
+++ b/browser.go
@@ -13,9 +13,10 @@ import (
 	"strings"
 	"time"
 
-	git "github.com/lhchavez/git2go/v32"
-	base "github.com/omegaup/go-base/v2"
+	git "github.com/libgit2/git2go/v32"
 	"github.com/pkg/errors"
+
+	base "github.com/omegaup/go-base/v2"
 )
 
 const (

--- a/browser_test.go
+++ b/browser_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	base "github.com/omegaup/go-base/v2"
 )
 

--- a/commits.go
+++ b/commits.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/inconshreveable/log15"
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	"github.com/pkg/errors"
 )
 

--- a/commits_test.go
+++ b/commits_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	base "github.com/omegaup/go-base/v2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,13 @@ module github.com/omegaup/githttp
 go 1.17
 
 require (
+	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
-	github.com/lhchavez/git2go/v32 v32.0.0-prerelease.0
+	github.com/libgit2/git2go/v32 v32.0.4
 	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/omegaup/go-base/v2 v2.1.0
 	github.com/pkg/errors v0.9.1
-)
-
-require (
-	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/mattn/go-isatty v0.0.12 // indirect
+	golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c // indirect
 	golang.org/x/sys v0.0.0-20201204225414-ed752295db88 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/inconshreveable/log15 v0.0.0-20200109203555-b30bc20e4fd1 h1:KUDFlmBg2
 github.com/inconshreveable/log15 v0.0.0-20200109203555-b30bc20e4fd1/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
 github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac h1:n1DqxAo4oWPMvH1+v+DLYlMCecgumhhgnxAPdqDIFHI=
 github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
-github.com/lhchavez/git2go/v32 v32.0.0-prerelease.0 h1:WulJqhctwHAenw8sNRWqJ1HVs3i97yjLXQF9Yjm58ME=
-github.com/lhchavez/git2go/v32 v32.0.0-prerelease.0/go.mod h1:0iSqM2vxVO1dfqzpi4eMzlp2mtjiMQ4S1/z89H2IIb8=
+github.com/libgit2/git2go/v32 v32.0.4 h1:qK2yWGh88K2Gh76E1+vUEsjKDfOAq0J2THKaoaFIPbA=
+github.com/libgit2/git2go/v32 v32.0.4/go.mod h1:FAA2ePV5PlLjw1ccncFIvu2v8hJSZVN5IzEn4lo/vwo=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=

--- a/packfile.go
+++ b/packfile.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	"github.com/pkg/errors"
 )
 

--- a/packfile_test.go
+++ b/packfile_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 )
 
 const (

--- a/protocol.go
+++ b/protocol.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/inconshreveable/log15"
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	base "github.com/omegaup/go-base/v2"
 	"github.com/pkg/errors"
 )

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	base "github.com/omegaup/go-base/v2"
 )
 

--- a/server.go
+++ b/server.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/inconshreveable/log15"
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	base "github.com/omegaup/go-base/v2"
 )
 

--- a/server_test.go
+++ b/server_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	base "github.com/omegaup/go-base/v2"
 )
 


### PR DESCRIPTION
Now that libgit2 v1.2.0 has been released, we no longer need to have a
fork (for now). #minor