### PR TITLE
Stop pretty-printing the marshaled response in browser

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -784,7 +784,5 @@ func handleBrowse(
 		_, err := w.Write(rawBytes)
 		return err
 	}
-	encoder := json.NewEncoder(w)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(result)
+	return json.NewEncoder(w).Encode(result)
 }


### PR DESCRIPTION
This change makes the marshaled response not pretty-print. This makes
things quite a bit faster.