### PR TITLE
Update go-base to the lastest and greatest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/libgit2/git2go/v33 v33.0.4
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
-	github.com/omegaup/go-base/v2 v2.2.0
+	github.com/omegaup/go-base/v2 v2.3.0
 	github.com/pkg/errors v0.9.1
 	golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c // indirect
 	golang.org/x/sys v0.0.0-20201204225414-ed752295db88 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/omegaup/go-base/v2 v2.1.0 h1:pehTzNMArOQrVBOa2oLhZDIhWSU80phIHrBi+gL4
 github.com/omegaup/go-base/v2 v2.1.0/go.mod h1:DotC1e60GE6S+iqe9RyusanekwK/eyU/YL3so86X3SA=
 github.com/omegaup/go-base/v2 v2.2.0 h1:bb4PrDOlJ+v17QHblBN3QGNTWoRhtgOW+k7x9q2L9Ik=
 github.com/omegaup/go-base/v2 v2.2.0/go.mod h1:DotC1e60GE6S+iqe9RyusanekwK/eyU/YL3so86X3SA=
+github.com/omegaup/go-base/v2 v2.3.0 h1:u5juOm0O96ZeuJu3xYSwvyGtstIkCEDT/F016gzSfow=
+github.com/omegaup/go-base/v2 v2.3.0/go.mod h1:DotC1e60GE6S+iqe9RyusanekwK/eyU/YL3so86X3SA=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
This should make it possible for downstream modules to import the
newrelic tracing module. #minor