### PR TITLE
Fix release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
 


### PR DESCRIPTION
We haven't been using the master branch in a while. Let's make the CI
reflect that.