### PR TITLE
Cancel the archive request when the context is canceled

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -552,11 +552,28 @@ func handleArchive(
 	}
 	defer tree.Free()
 
+	select {
+	case <-ctx.Done():
+		return errors.Wrap(
+			ctx.Err(),
+			"context cancelled",
+		)
+	default:
+	}
+
 	w.Header().Set("Content-Type", contentType)
 	z := zip.NewWriter(w)
 	defer z.Close()
 
 	err = tree.Walk(func(parent string, entry *git.TreeEntry) error {
+		select {
+		case <-ctx.Done():
+			return errors.Wrap(
+				ctx.Err(),
+				"context cancelled",
+			)
+		default:
+		}
 		fullPath := path.Join(parent, entry.Name)
 		if entry.Type == git.ObjectTree {
 			_, err := z.CreateHeader(&zip.FileHeader{


### PR DESCRIPTION
Previously it was possible for the request to go forever unless there
was an explicit failure in any of the `.Write()` calls.

This change makes it such that context deadlines can now cause the
request to exit early if possible.