### PR TITLE
Cache the Lockfiles

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -885,6 +885,7 @@ func handleShow(
 
 func handleBrowse(
 	ctx context.Context,
+	m *LockfileManager,
 	repositoryPath string,
 	level AuthorizationLevel,
 	protocol *GitProtocol,
@@ -904,7 +905,7 @@ func handleBrowse(
 	}
 	defer repository.Free()
 
-	lockfile := NewLockfile(repository.Path())
+	lockfile := m.NewLockfile(repository.Path())
 	if ok, err := lockfile.TryRLock(); !ok {
 		protocol.log.Info(
 			"Waiting for the lockfile",

--- a/browser_test.go
+++ b/browser_test.go
@@ -566,6 +566,7 @@ func TestHandleShowBlob(t *testing.T) {
 
 func TestHandleNotFound(t *testing.T) {
 	log, _ := log15.New("info", false)
+	lockfileManager := NewLockfileManager()
 	protocol := NewGitProtocol(GitProtocolOpts{
 		ReferenceDiscoveryCallback: func(
 			ctx context.Context,
@@ -613,6 +614,7 @@ func TestHandleNotFound(t *testing.T) {
 
 		err = handleBrowse(
 			context.Background(),
+			lockfileManager,
 			"testdata/repo.git",
 			AuthorizationAllowed,
 			protocol,

--- a/lockfile.go
+++ b/lockfile.go
@@ -3,38 +3,82 @@ package githttp
 import (
 	"path/filepath"
 	"syscall"
+
+	"github.com/omegaup/go-base/v3"
 )
 
+// LockfileState represents the stat of the lockfile.
+type LockfileState int
+
 const (
-	invalidFd = -1
+	invalidFD = -1
+
+	// LockfileStateUnlocked represents that a lockfile is not locked.
+	LockfileStateUnlocked LockfileState = iota
+	// LockfileStateReadLocked represents that a lockfile has acquired a read lock.
+	LockfileStateReadLocked
+	// LockfileStateLocked represents that a lockfile has acquired a read/write lock.
+	LockfileStateLocked
 )
+
+// LockfileManager is a container for Lockfiles, which allows them to be reused
+// between calls safely.
+type LockfileManager struct {
+	fdCache *base.KeyedPool[int]
+}
+
+// NewLockfileManager returns a new LockfileManager.
+func NewLockfileManager() *LockfileManager {
+	return &LockfileManager{
+		fdCache: base.NewKeyedPool[int](base.KeyedPoolOptions[int]{
+			New: func(path string) (int, error) {
+				return syscall.Creat(path, 0600)
+			},
+			OnEvicted: func(path string, value int) {
+				syscall.Close(value)
+			},
+		}),
+	}
+}
+
+// Clear releases all the lockfiles in the pool.
+func (m *LockfileManager) Clear() {
+	m.fdCache.Clear()
+}
 
 // Lockfile represents a file-based lock that can be up/downgraded.  Since this
 // is using the flock(2) system call and the promotion/demotion is non-atomic,
 // any attempt to change the lock type must verify any preconditions after
 // calling Lock()/RLock().
 type Lockfile struct {
-	path string
-	fd   int
+	path    string
+	fd      int
+	state   LockfileState
+	fdCache *base.KeyedPool[int]
 }
 
 // NewLockfile creates a new Lockfile that is initially unlocked.
-func NewLockfile(repositoryPath string) *Lockfile {
+func (m *LockfileManager) NewLockfile(repositoryPath string) *Lockfile {
 	return &Lockfile{
-		path: filepath.Join(repositoryPath, "githttp.lock"),
-		fd:   invalidFd,
+		path:    filepath.Join(repositoryPath, "githttp.lock"),
+		fd:      invalidFD,
+		fdCache: m.fdCache,
 	}
 }
 
 func (l *Lockfile) open() error {
-	if l.fd != invalidFd {
+	if l.fd != invalidFD {
 		return nil
 	}
-	f, err := syscall.Creat(l.path, 0600)
+
+	// This will reuse a previous (unlocked) lockfile if possible. Otherwise, it
+	// will open a new one.
+	fd, err := l.fdCache.Get(l.path)
 	if err != nil {
 		return err
 	}
-	l.fd = f
+	l.fd = fd
+
 	return nil
 }
 
@@ -51,6 +95,7 @@ func (l *Lockfile) TryRLock() (bool, error) {
 		}
 		return false, err
 	}
+	l.state = LockfileStateReadLocked
 	return true, nil
 }
 
@@ -61,7 +106,11 @@ func (l *Lockfile) RLock() error {
 	if err := l.open(); err != nil {
 		return err
 	}
-	return syscall.Flock(l.fd, syscall.LOCK_SH)
+	if err := syscall.Flock(l.fd, syscall.LOCK_SH); err != nil {
+		return err
+	}
+	l.state = LockfileStateReadLocked
+	return nil
 }
 
 // TryLock attempts to acquire an exclusive lock for the Lockfile's path and
@@ -77,6 +126,7 @@ func (l *Lockfile) TryLock() (bool, error) {
 		}
 		return false, err
 	}
+	l.state = LockfileStateLocked
 	return true, nil
 }
 
@@ -87,17 +137,32 @@ func (l *Lockfile) Lock() error {
 	if err := l.open(); err != nil {
 		return err
 	}
-	return syscall.Flock(l.fd, syscall.LOCK_EX)
+	if err := syscall.Flock(l.fd, syscall.LOCK_EX); err != nil {
+		return err
+	}
+	l.state = LockfileStateLocked
+	return nil
 }
 
 // Unlock releases a lock for the Lockfile's path.
 func (l *Lockfile) Unlock() error {
-	if l.fd == invalidFd {
+	if l.fd == invalidFD {
 		return nil
 	}
-	if err := syscall.Close(l.fd); err != nil {
-		return err
+	err := syscall.Flock(l.fd, syscall.LOCK_UN)
+	if err != nil {
+		// We could not remove the lock, so let's just close the fd.
+		syscall.Close(l.fd)
+	} else {
+		// The file is now unlocked. We can reuse it later.
+		l.fdCache.Put(l.path, l.fd)
 	}
-	l.fd = invalidFd
-	return nil
+	l.fd = invalidFD
+	l.state = LockfileStateUnlocked
+	return err
+}
+
+// State returns the Lockfile's current state.
+func (l *Lockfile) State() LockfileState {
+	return l.state
 }

--- a/lockfile_test.go
+++ b/lockfile_test.go
@@ -16,7 +16,10 @@ func TestUpgradeLock(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	l := NewLockfile(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
+
+	l := m.NewLockfile(dir)
 	if err := l.RLock(); err != nil {
 		t.Fatalf("Failed to lock git repository for reading: %v", err)
 	}
@@ -63,7 +66,10 @@ func TestMultipleReadersLock(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	l := NewLockfile(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
+
+	l := m.NewLockfile(dir)
 	if err = l.RLock(); err != nil {
 		t.Fatalf("Failed to lock git repository for reading: %v", err)
 	}
@@ -74,7 +80,7 @@ func TestMultipleReadersLock(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			l := NewLockfile(dir)
+			l := m.NewLockfile(dir)
 			if err := l.RLock(); err != nil {
 				t.Errorf("Failed to lock git repository for reading: %v", err)
 				panic(err)
@@ -93,13 +99,16 @@ func TestSingleWriterLock(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
+	m := NewLockfileManager()
+	defer m.Clear()
+
 	var writerCount int32
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			l := NewLockfile(dir)
+			l := m.NewLockfile(dir)
 			if err := l.Lock(); err != nil {
 				t.Errorf("Failed to lock git repository for reading: %v", err)
 				panic(err)

--- a/protocol.go
+++ b/protocol.go
@@ -476,6 +476,7 @@ func commitPackfile(packPath string, writepack *git.OdbWritepack) error {
 // what references to push/pull.
 func handleInfoRefs(
 	ctx context.Context,
+	m *LockfileManager,
 	repositoryPath string,
 	serviceName string,
 	capabilities Capabilities,
@@ -495,7 +496,7 @@ func handleInfoRefs(
 	}
 	defer repository.Free()
 
-	lockfile := NewLockfile(repository.Path())
+	lockfile := m.NewLockfile(repository.Path())
 	if ok, err := lockfile.TryRLock(); !ok {
 		log.Info(
 			"Waiting for the lockfile",
@@ -602,6 +603,7 @@ func handleInfoRefs(
 // discovery.
 func handlePrePull(
 	ctx context.Context,
+	m *LockfileManager,
 	repositoryPath string,
 	level AuthorizationLevel,
 	protocol *GitProtocol,
@@ -610,6 +612,7 @@ func handlePrePull(
 ) error {
 	return handleInfoRefs(
 		ctx,
+		m,
 		repositoryPath,
 		"git-upload-pack",
 		pullCapabilities,
@@ -628,6 +631,7 @@ func handlePrePull(
 // contained in the requested commits.
 func handlePull(
 	ctx context.Context,
+	m *LockfileManager,
 	repositoryPath string,
 	level AuthorizationLevel,
 	log logging.Logger,
@@ -643,7 +647,7 @@ func handlePull(
 	}
 	defer repository.Free()
 
-	lockfile := NewLockfile(repository.Path())
+	lockfile := m.NewLockfile(repository.Path())
 	if ok, err := lockfile.TryRLock(); !ok {
 		log.Info(
 			"Waiting for the lockfile",
@@ -933,6 +937,7 @@ func handlePull(
 // references it can update.
 func handlePrePush(
 	ctx context.Context,
+	m *LockfileManager,
 	repositoryPath string,
 	level AuthorizationLevel,
 	protocol *GitProtocol,
@@ -941,6 +946,7 @@ func handlePrePush(
 ) error {
 	return handleInfoRefs(
 		ctx,
+		m,
 		repositoryPath,
 		"git-receive-pack",
 		pushCapabilities,
@@ -958,6 +964,7 @@ func handlePrePush(
 // and commits the change if it is allowed.
 func handlePush(
 	ctx context.Context,
+	m *LockfileManager,
 	repositoryPath string,
 	level AuthorizationLevel,
 	protocol *GitProtocol,
@@ -974,7 +981,7 @@ func handlePush(
 	}
 	defer repository.Free()
 
-	lockfile := NewLockfile(repository.Path())
+	lockfile := m.NewLockfile(repository.Path())
 	if ok, err := lockfile.TryRLock(); !ok {
 		log.Info(
 			"Waiting for the lockfile",

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -60,8 +60,12 @@ func TestDiscoverReferences(t *testing.T) {
 func TestHandlePrePullRestricted(t *testing.T) {
 	var buf bytes.Buffer
 	log, _ := log15.New("info", false)
+	m := NewLockfileManager()
+	defer m.Clear()
+
 	err := handlePrePull(
 		context.Background(),
+		m,
 		"testdata/repo.git",
 		AuthorizationAllowedRestricted,
 		NewGitProtocol(GitProtocolOpts{
@@ -93,8 +97,12 @@ func TestHandlePrePullRestricted(t *testing.T) {
 func TestHandlePrePull(t *testing.T) {
 	var buf bytes.Buffer
 	log, _ := log15.New("info", false)
+	m := NewLockfileManager()
+	defer m.Clear()
+
 	err := handlePrePull(
 		context.Background(),
+		m,
 		"testdata/repo.git",
 		AuthorizationAllowed,
 		NewGitProtocol(GitProtocolOpts{
@@ -127,8 +135,12 @@ func TestHandlePrePull(t *testing.T) {
 func TestHandlePrePush(t *testing.T) {
 	var buf bytes.Buffer
 	log, _ := log15.New("info", false)
+	m := NewLockfileManager()
+	defer m.Clear()
+
 	err := handlePrePush(
 		context.Background(),
+		m,
 		"testdata/repo.git",
 		AuthorizationAllowed,
 		NewGitProtocol(GitProtocolOpts{
@@ -160,8 +172,12 @@ func TestHandlePrePush(t *testing.T) {
 func TestHandleEmptyPrePull(t *testing.T) {
 	var buf bytes.Buffer
 	log, _ := log15.New("info", false)
+	m := NewLockfileManager()
+	defer m.Clear()
+
 	err := handlePrePull(
 		context.Background(),
+		m,
 		"testdata/empty.git",
 		AuthorizationAllowed,
 		NewGitProtocol(GitProtocolOpts{
@@ -190,8 +206,12 @@ func TestHandleEmptyPrePull(t *testing.T) {
 func TestHandleEmptyPrePush(t *testing.T) {
 	var buf bytes.Buffer
 	log, _ := log15.New("info", false)
+	m := NewLockfileManager()
+	defer m.Clear()
+
 	err := handlePrePush(
 		context.Background(),
+		m,
 		"testdata/empty.git",
 		AuthorizationAllowed,
 		NewGitProtocol(GitProtocolOpts{
@@ -227,6 +247,8 @@ func TestHandlePullUnknownRef(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		// Taken from git 2.14.1
@@ -239,6 +261,7 @@ func TestHandlePullUnknownRef(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePull(
 		context.Background(),
+		m,
 		"testdata/repo.git",
 		AuthorizationAllowed,
 		log,
@@ -268,6 +291,8 @@ func TestHandleClone(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		// Taken from git 2.14.1
@@ -280,6 +305,7 @@ func TestHandleClone(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePull(
 		context.Background(),
+		m,
 		"testdata/repo.git",
 		AuthorizationAllowed,
 		log,
@@ -343,6 +369,8 @@ func TestHandlePull(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		// Taken from git 2.14.1
@@ -356,6 +384,7 @@ func TestHandlePull(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePull(
 		context.Background(),
+		m,
 		"testdata/repo.git",
 		AuthorizationAllowed,
 		log,
@@ -415,6 +444,8 @@ func TestHandleCloneShallowNegotiation(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		// Taken from git 2.14.1
@@ -427,6 +458,7 @@ func TestHandleCloneShallowNegotiation(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePull(
 		context.Background(),
+		m,
 		"testdata/repo.git",
 		AuthorizationAllowed,
 		log,
@@ -456,6 +488,8 @@ func TestHandleCloneShallowClone(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		// Taken from git 2.14.1
@@ -469,6 +503,7 @@ func TestHandleCloneShallowClone(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePull(
 		context.Background(),
+		m,
 		"testdata/repo.git",
 		AuthorizationAllowed,
 		log,
@@ -531,6 +566,8 @@ func TestHandleCloneShallowUnshallow(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		// Taken from git 2.14.1
@@ -546,6 +583,7 @@ func TestHandleCloneShallowUnshallow(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePull(
 		context.Background(),
+		m,
 		"testdata/repo.git",
 		AuthorizationAllowed,
 		log,
@@ -608,6 +646,8 @@ func TestHandlePushUnborn(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		repo, err := git.InitRepository(dir, true)
@@ -636,6 +676,7 @@ func TestHandlePushUnborn(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePush(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowed,
 		NewGitProtocol(GitProtocolOpts{
@@ -664,6 +705,7 @@ func TestHandlePushUnborn(t *testing.T) {
 	var buf bytes.Buffer
 	err = handlePrePull(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowed,
 		NewGitProtocol(GitProtocolOpts{
@@ -701,6 +743,8 @@ func TestHandlePushPreprocess(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(dir)
 	}
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		repo, err := git.InitRepository(dir, true)
@@ -729,6 +773,7 @@ func TestHandlePushPreprocess(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePush(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowed,
 		NewGitProtocol(GitProtocolOpts{
@@ -836,6 +881,7 @@ func TestHandlePushPreprocess(t *testing.T) {
 	var buf bytes.Buffer
 	err = handlePrePull(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowed,
 		NewGitProtocol(GitProtocolOpts{
@@ -873,6 +919,8 @@ func TestHandlePushCallback(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		repo, err := git.InitRepository(dir, true)
@@ -901,6 +949,7 @@ func TestHandlePushCallback(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePush(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowed,
 		NewGitProtocol(GitProtocolOpts{
@@ -943,6 +992,8 @@ func TestHandlePushUnknownCommit(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		repo, err := git.InitRepository(dir, true)
@@ -971,6 +1022,7 @@ func TestHandlePushUnknownCommit(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePush(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowed,
 		NewGitProtocol(GitProtocolOpts{
@@ -1004,6 +1056,8 @@ func TestHandlePushRestrictedRef(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		repo, err := git.InitRepository(dir, true)
@@ -1032,6 +1086,7 @@ func TestHandlePushRestrictedRef(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePush(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowedRestricted,
 		NewGitProtocol(GitProtocolOpts{
@@ -1065,6 +1120,8 @@ func TestHandlePushMerge(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		repo, err := git.InitRepository(dir, true)
@@ -1093,6 +1150,7 @@ func TestHandlePushMerge(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePush(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowedRestricted,
 		NewGitProtocol(GitProtocolOpts{
@@ -1126,6 +1184,8 @@ func TestHandlePushMultipleCommits(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		repo, err := git.InitRepository(dir, true)
@@ -1154,6 +1214,7 @@ func TestHandlePushMultipleCommits(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePush(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowedRestricted,
 		NewGitProtocol(GitProtocolOpts{
@@ -1187,6 +1248,8 @@ func TestHandleNonFastForward(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		repo, err := git.InitRepository(dir, true)
@@ -1215,6 +1278,7 @@ func TestHandleNonFastForward(t *testing.T) {
 	log, _ := log15.New("info", false)
 	err = handlePush(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowedRestricted,
 		NewGitProtocol(GitProtocolOpts{
@@ -1259,6 +1323,7 @@ func TestHandleNonFastForward(t *testing.T) {
 
 	err = handlePush(
 		context.Background(),
+		m,
 		dir,
 		AuthorizationAllowedRestricted,
 		NewGitProtocol(GitProtocolOpts{

--- a/server_test.go
+++ b/server_test.go
@@ -47,6 +47,8 @@ func TestServerClone(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	log, _ := log15.New("info", false)
 	handler := NewGitServer(GitServerOpts{
@@ -57,7 +59,8 @@ func TestServerClone(t *testing.T) {
 			AuthCallback: allowAuthorizationCallback,
 			Log:          log,
 		}),
-		Log: log,
+		LockfileManager: m,
+		Log:             log,
 	})
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
@@ -91,6 +94,8 @@ func TestServerCloneShallow(t *testing.T) {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	log, _ := log15.New("info", false)
 	handler := NewGitServer(GitServerOpts{
@@ -101,7 +106,8 @@ func TestServerCloneShallow(t *testing.T) {
 			AuthCallback: allowAuthorizationCallback,
 			Log:          log,
 		}),
-		Log: log,
+		LockfileManager: m,
+		Log:             log,
 	})
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
@@ -158,6 +164,8 @@ func TestServerPush(t *testing.T) {
 	} else {
 		defer os.RemoveAll(dir)
 	}
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		repo, err := git.InitRepository(filepath.Join(dir, "repo.git"), true)
@@ -175,7 +183,8 @@ func TestServerPush(t *testing.T) {
 			AuthCallback: allowAuthorizationCallback,
 			Log:          log,
 		}),
-		Log: log,
+		LockfileManager: m,
+		Log:             log,
 	})
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
@@ -258,6 +267,8 @@ func TestGitbomb(t *testing.T) {
 	} else {
 		defer os.RemoveAll(dir)
 	}
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	{
 		repo, err := git.InitRepository(filepath.Join(dir, "repo.git"), true)
@@ -275,7 +286,8 @@ func TestGitbomb(t *testing.T) {
 			AuthCallback: allowAuthorizationCallback,
 			Log:          log,
 		}),
-		Log: log,
+		LockfileManager: m,
+		Log:             log,
 	})
 	ts := httptest.NewServer(handler)
 	defer ts.Close()


### PR DESCRIPTION
This change creates a pool of lockfiles to avoid having to open files every single time.  Instead, after a lockfile is unlocked, it will be placed in the pool for it to be reused next time.