### PR TITLE
Introduce RepositoryHandle

### DIFF
--- a/browser_test.go
+++ b/browser_test.go
@@ -29,10 +29,11 @@ func TestHandleRefs(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	result, err := handleRefs(
 		context.Background(),
-		repository,
+		handle,
 		AuthorizationAllowed,
 		protocol,
 		"GET",
@@ -76,10 +77,11 @@ func TestHandleRefsWithReferenceDiscoveryCallback(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	result, err := handleRefs(
 		context.Background(),
-		repository,
+		handle,
 		AuthorizationAllowed,
 		protocol,
 		"GET",
@@ -105,10 +107,11 @@ func TestHandleRestrictedRefs(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	result, err := handleRefs(
 		context.Background(),
-		repository,
+		handle,
 		AuthorizationAllowedRestricted,
 		protocol,
 		"GET",
@@ -142,6 +145,7 @@ func TestHandleArchiveCommitZip(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	requestPath := "/+archive/88aa3454adb27c3c343ab57564d962a0a7f6a3c1.zip"
 	req, err := http.NewRequest("GET", "http://test"+requestPath, nil)
@@ -153,7 +157,7 @@ func TestHandleArchiveCommitZip(t *testing.T) {
 	response := httptest.NewRecorder()
 	if err := handleArchive(
 		context.Background(),
-		repository,
+		handle,
 		AuthorizationAllowed,
 		protocol,
 		requestPath,
@@ -186,6 +190,7 @@ func TestHandleArchiveCommitTarball(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	requestPath := "/+archive/88aa3454adb27c3c343ab57564d962a0a7f6a3c1.tar.gz"
 	req, err := http.NewRequest("GET", "http://test"+requestPath, nil)
@@ -198,7 +203,7 @@ func TestHandleArchiveCommitTarball(t *testing.T) {
 	response := httptest.NewRecorder()
 	if err := handleArchive(
 		context.Background(),
-		repository,
+		handle,
 		AuthorizationAllowed,
 		protocol,
 		requestPath,
@@ -255,6 +260,7 @@ func TestHandleArchiveCommitTarballFromTree(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	requestPath := "/+archive/417c01c8795a35b8e835113a85a5c0c1c77f67fb.tar.gz"
 	req, err := http.NewRequest("GET", "http://test"+requestPath, nil)
@@ -266,7 +272,7 @@ func TestHandleArchiveCommitTarballFromTree(t *testing.T) {
 	response := httptest.NewRecorder()
 	if err := handleArchive(
 		context.Background(),
-		repository,
+		handle,
 		AuthorizationAllowed,
 		protocol,
 		requestPath,
@@ -323,10 +329,11 @@ func TestHandleLog(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	result, err := handleLog(
 		context.Background(),
-		repository,
+		handle,
 		AuthorizationAllowed,
 		protocol,
 		"/+log/",
@@ -388,10 +395,11 @@ func TestHandleLogCommit(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	result, err := handleLog(
 		context.Background(),
-		repository,
+		handle,
 		AuthorizationAllowed,
 		protocol,
 		"/+log/88aa3454adb27c3c343ab57564d962a0a7f6a3c1",
@@ -437,10 +445,11 @@ func TestHandleShowCommit(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	result, err := handleShow(
 		context.Background(),
-		repository,
+		handle,
 		AuthorizationAllowed,
 		protocol,
 		"/+/88aa3454adb27c3c343ab57564d962a0a7f6a3c1",
@@ -483,6 +492,7 @@ func TestHandleShowTree(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	expected := &TreeResult{
 		ID: "417c01c8795a35b8e835113a85a5c0c1c77f67fb",
@@ -505,7 +515,7 @@ func TestHandleShowTree(t *testing.T) {
 	} {
 		result, err := handleShow(
 			context.Background(),
-			repository,
+			handle,
 			AuthorizationAllowed,
 			protocol,
 			requestURL,
@@ -533,6 +543,7 @@ func TestHandleShowBlob(t *testing.T) {
 		t.Fatalf("Error opening git repository: %v", err)
 	}
 	defer repository.Free()
+	handle := &RepositoryHandle{Repository: repository}
 
 	expected := &BlobResult{
 		ID:       "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
@@ -548,7 +559,7 @@ func TestHandleShowBlob(t *testing.T) {
 	} {
 		result, err := handleShow(
 			context.Background(),
-			repository,
+			handle,
 			AuthorizationAllowed,
 			protocol,
 			requestURL,

--- a/commits_test.go
+++ b/commits_test.go
@@ -243,6 +243,8 @@ func TestSpliceCommit(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(dir)
 	}
+	m := NewLockfileManager()
+	defer m.Clear()
 
 	repository, err := git.InitRepository(dir, true)
 	if err != nil {
@@ -304,6 +306,7 @@ func TestSpliceCommit(t *testing.T) {
 	newPackPath := path.Join(dir, "new.pack")
 	newCommands, err := SpliceCommit(
 		repository,
+		m,
 		originalCommit,
 		nil,
 		map[string]io.Reader{

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -803,6 +803,7 @@ func TestHandlePushPreprocess(t *testing.T) {
 				newPackPath := path.Join(tmpDir, "new.pack")
 				newCommands, err := SpliceCommit(
 					originalRepository,
+					m,
 					originalCommit,
 					nil,
 					map[string]io.Reader{},

--- a/repository_handle.go
+++ b/repository_handle.go
@@ -1,0 +1,212 @@
+package githttp
+
+import (
+	"context"
+	"sync"
+
+	"github.com/omegaup/go-base/v3"
+	"github.com/omegaup/go-base/v3/logging"
+	"github.com/omegaup/go-base/v3/tracing"
+
+	git "github.com/libgit2/git2go/v33"
+	"github.com/pkg/errors"
+)
+
+var (
+	repositoryHandlePool     *base.KeyedPool[*RepositoryHandle]
+	repositoryHandlePoolOnce sync.Once
+)
+
+// RepositoryHandle contains a reference to an open git repository and its
+// lockfile. It also contains lazily-obtained references.
+type RepositoryHandle struct {
+	Repository        *git.Repository
+	Lockfile          *Lockfile
+	DoNotReturnToPool bool
+
+	path       string
+	references []*RepositoryReference
+	log        logging.Logger
+}
+
+func newRepositoryHandle(m *LockfileManager, path string, log logging.Logger) (*RepositoryHandle, error) {
+	log.Info(
+		"Acquiring a repository handle",
+		map[string]any{
+			"path": path,
+		},
+	)
+	repository, err := git.OpenRepository(path)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to open git repository at %q",
+			path,
+		)
+	}
+
+	return &RepositoryHandle{
+		Repository: repository,
+		Lockfile:   m.NewLockfile(repository.Path()),
+
+		path: path,
+		log:  log,
+	}, nil
+}
+
+// OpenRepositoryHandle opens a git repository and returns a handle to it.
+// Opening git repositories from scratch is moderately expensive, so once the
+// caller is done with the handle, they can Release() it into an object pool so
+// that it can be reused again in the future (unless the repository has
+// changed).
+func OpenRepositoryHandle(ctx context.Context, m *LockfileManager, path string, log logging.Logger) (*RepositoryHandle, error) {
+	txn := tracing.FromContext(ctx)
+	defer txn.StartSegment("OpenRepositoryHandle").End()
+	repositoryHandlePoolOnce.Do(func() {
+		repositoryHandlePool = base.NewKeyedPool(base.KeyedPoolOptions[*RepositoryHandle]{
+			New: func(path string) (*RepositoryHandle, error) {
+				return newRepositoryHandle(m, path, log)
+			},
+			OnEvicted: func(key string, value *RepositoryHandle) {
+				value.free()
+			},
+		})
+	})
+
+	handle, err := repositoryHandlePool.Get(path)
+	if err != nil {
+		return nil, err
+	}
+
+	defer txn.StartSegment("acquire lock").End()
+	if ok, err := handle.Lockfile.TryRLock(); !ok {
+		log.Info(
+			"Waiting for the lockfile",
+			map[string]any{
+				"err": err,
+			},
+		)
+		// If we failed to acquire the read lock immediately, it means that there's
+		// another handle that's currently writing to the repository. When that
+		// happens, we cannot rely on the cached information from the previously
+		// opened handle, so we need to create a brand new one.
+		handle.DoNotReturnToPool = true
+		handle.Release()
+
+		handle, err = newRepositoryHandle(m, path, log)
+		if err != nil {
+			return nil, err
+		}
+		if err := handle.Lockfile.RLock(); err != nil {
+			handle.Release()
+			return nil, errors.Wrapf(
+				err,
+				"failed to acquire the lockfile at %q",
+				path,
+			)
+		}
+	}
+
+	return handle, nil
+}
+
+// EvictRepositoryHandles removes any repository handles that exist in the
+// handle pool. This should be called if a particular repository is modified to
+// invalidate all cached objects.
+func EvictRepositoryHandles(path string) {
+	repositoryHandlePool.Remove(path)
+}
+
+// Release releases the repositoy and puts it back into the pool unless
+// DoNotReturnToPool was set, in which case the resources are immediately freed
+// and forgotten.
+//
+// Once in the pool's ownership, the underlying repository can be freed at some
+// point in the future.
+func (h *RepositoryHandle) Release() {
+	h.Lockfile.Unlock()
+	if h.DoNotReturnToPool {
+		h.free()
+		return
+	}
+	repositoryHandlePool.Put(h.path, h)
+}
+
+func (h *RepositoryHandle) free() {
+	h.log.Info(
+		"Releasing a repository handle",
+		map[string]any{
+			"path": h.path,
+		},
+	)
+	h.Repository.Free()
+}
+
+// RepositoryReference contains the fully resolved information of a
+// git.Reference.
+type RepositoryReference struct {
+	Name           string
+	Target         *git.Oid
+	SymbolicTarget string
+}
+
+// References returns the list of all references (after fully resolving them)
+// in the repository. This information is lazily computed the first time it's
+// used and then cached for future usages.
+func (h *RepositoryHandle) References() ([]*RepositoryReference, error) {
+	if h.references == nil {
+		it, err := h.Repository.NewReferenceIterator()
+		if err != nil {
+			return nil, errors.Wrap(
+				err,
+				"failed to create a reference iterator",
+			)
+		}
+		defer it.Free()
+
+		// Make sure this is non-nil even if it's empty.
+		references := []*RepositoryReference{}
+		for {
+			ref, err := it.Next()
+			if err != nil {
+				if git.IsErrorCode(err, git.ErrorCodeIterOver) {
+					break
+				}
+
+				return nil, errors.Wrap(
+					err,
+					"failed to read next reference",
+				)
+			}
+
+			if ref.Type() == git.ReferenceSymbolic {
+				target, err := ref.Resolve()
+				if err != nil {
+					ref.Free()
+					return nil, errors.Wrapf(
+						err,
+						"failed to resolve the symbolic target for %s(%s)",
+						ref.Name(),
+						ref.Target(),
+					)
+				}
+				references = append(references, &RepositoryReference{
+					Name:           ref.Name(),
+					Target:         target.Target(),
+					SymbolicTarget: ref.SymbolicTarget(),
+				})
+				target.Free()
+			} else if ref.Type() == git.ReferenceOid {
+				references = append(references, &RepositoryReference{
+					Name:   ref.Name(),
+					Target: ref.Target(),
+				})
+			}
+			ref.Free()
+		}
+
+		h.references = references
+	}
+
+	return h.references, nil
+}


### PR DESCRIPTION
This change adds a way to cache git Repositories between invocations. This reduces the number of CGO calls, since each one of those is pretty slow.